### PR TITLE
Fix `depends_on :python` deprecation warning

### DIFF
--- a/neovim-dot-app.rb
+++ b/neovim-dot-app.rb
@@ -11,7 +11,7 @@ class NeovimDotApp < Formula
   depends_on "neovim"
 
   # scons requires python 2
-  depends_on :python => :recommended
+  depends_on "python" => :recommended
   depends_on :xcode
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
This fixes a Homebrew deprecation warning:

```
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/rogual/homebrew-neovim-dot-app/neovim-dot-app.rb:14:in `<class:NeovimDotApp>'
Please report this to the rogual/neovim-dot-app tap!
```